### PR TITLE
add CFN outputs

### DIFF
--- a/energy_comparison_table/energy_comparison_table_stack.py
+++ b/energy_comparison_table/energy_comparison_table_stack.py
@@ -1,4 +1,5 @@
 from aws_cdk import (
+    CfnOutput,
     Duration,
     RemovalPolicy,
     Stack,
@@ -72,3 +73,7 @@ class EnergyComparisonTableStack(Stack):
         )
         cdn.grant_create_invalidation(site_generator)
         site_generator.add_environment("DISTRIBUTION_ID", cdn.distribution_id)
+
+        CfnOutput(self, "WebsiteBucket", value=bucket.bucket_name)
+        CfnOutput(self, "LambdaArn", value=site_generator.function_arn)
+        CfnOutput(self, "Endpoint", value=cdn.domain_name)


### PR DESCRIPTION
adds cfn outputs for the cdn endpoint, the lambda ARN and the bucket name. You can access them on the jenkins build page under `Build Artifacts` , e.g https://jenkins.devops.citizensadvice.org.uk/job/energy-comparison-table/job/main/2/ ( this particular build has no outputs though, since they are added by this PR )


<!-- auto generated content; do not edit this line and below -->
#### Changes to MAIN if this PR is merged:

<details>
<summary>Changes</summary>

```
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
Stack EnergyComparisonTableStack
Outputs
[+] Output WebsiteBucket WebsiteBucket: {"Value":{"Ref":"Bucket83908E77"}}
[+] Output LambdaArn LambdaArn: {"Value":{"Fn::GetAtt":["LambdaD247545B","Arn"]}}
[+] Output Endpoint Endpoint: {"Value":{"Fn::GetAtt":["Cdn9963B1AD","DomainName"]}}



```

</details>
