### PR TITLE
fix: remove old gemfile gitsource  code

### DIFF
--- a/bridgetown/energy_tables/Gemfile
+++ b/bridgetown/energy_tables/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+# git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ####
 # Welcome to your project's Gemfile, used by Rubygems & Bundler.


### PR DESCRIPTION

<!-- auto generated content; do not edit this line and below -->
#### Changes to MAIN if this PR is merged:

<details>
<summary>Changes</summary>

```
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
Stack EnergyComparisonTableStack
Resources
[~] AWS::Lambda::Function Lambda LambdaD247545B 
 └─ [~] Code
     └─ [~] .ImageUri:
         └─ [~] .Fn::Join:
             └─ @@ -5,6 +5,6 @@
                [ ]     {
                [ ]       "Ref": "AWS::URLSuffix"
                [ ]     },
                [-]     "/cdk-hnb659fds-container-assets-979633842206-eu-west-1:67691b29014838ffe7a6eb439eb68141581d31b20085763755ccb5339c6bfbc2"
                [+]     "/cdk-hnb659fds-container-assets-979633842206-eu-west-1:81d3036c72946160499d4004de86e4bdfaf729278e5fe7622dd1d4df3941b2cf"
                [ ]   ]
                [ ] ]



```

</details>
