### PR TITLE
fix: run bundler setup

### DIFF
--- a/bridgetown/energy_tables/config.ru
+++ b/bridgetown/energy_tables/config.ru
@@ -1,6 +1,9 @@
 # This file is used by Rack-based servers during the Bridgetown boot process.
 
 require "bridgetown-core/rack/boot"
+require 'bundler/setup'
+
+Bundler.setup
 
 Bridgetown::Rack.boot
 


### PR DESCRIPTION
Bundler is installing the citizens advice gem but bridgetown cannot find the gem when running.  

Interestingly, it's the only gem installed from github and is installed to
```
vendor/ruby/3.2.0/bundler/gems
```

instead of 

```
vendor/ruby/3.2.0/gems
```
<!-- auto generated content; do not edit this line and below -->
#### Changes to MAIN if this PR is merged:

<details>
<summary>Changes</summary>

```
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
Stack EnergyComparisonTableStack
There were no differences


```

</details>
