### PR TITLE
fix: move bundler setup

### DIFF
--- a/bridgetown/energy_tables/config.ru
+++ b/bridgetown/energy_tables/config.ru
@@ -1,9 +1,6 @@
 # This file is used by Rack-based servers during the Bridgetown boot process.
 
 require "bridgetown-core/rack/boot"
-require 'bundler/setup'
-
-Bundler.setup
 
 Bridgetown::Rack.boot
 

--- a/bridgetown/energy_tables/plugins/builders/suppliers_builder.rb
+++ b/bridgetown/energy_tables/plugins/builders/suppliers_builder.rb
@@ -1,3 +1,5 @@
+require 'bundler/setup'
+
 module Builders
   class SuppliersBuilder < SiteBuilder
     def build


### PR DESCRIPTION

<!-- auto generated content; do not edit this line and below -->
#### Changes to MAIN if this PR is merged:

<details>
<summary>Changes</summary>

```
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
Stack EnergyComparisonTableStack
Resources
[~] AWS::Lambda::Function Lambda LambdaD247545B 
 └─ [~] Code
     └─ [~] .ImageUri:
         └─ [~] .Fn::Join:
             └─ @@ -5,6 +5,6 @@
                [ ]     {
                [ ]       "Ref": "AWS::URLSuffix"
                [ ]     },
                [-]     "/cdk-hnb659fds-container-assets-979633842206-eu-west-1:35c24dffa2513b71f7d484068aaa425702d6d78fbf88c3160846c62968aa1425"
                [+]     "/cdk-hnb659fds-container-assets-979633842206-eu-west-1:5c668a254faed25d72d3481148dbb4afd915d2135df81e8acd8402df1bd4789e"
                [ ]   ]
                [ ] ]



```

</details>
