### PR TITLE
fix/cads gem

### DIFF
--- a/bridgetown/energy_tables/plugins/builders/suppliers_builder.rb
+++ b/bridgetown/energy_tables/plugins/builders/suppliers_builder.rb
@@ -1,5 +1,3 @@
-require 'bundler/setup'
-
 module Builders
   class SuppliersBuilder < SiteBuilder
     def build

--- a/bridgetown/handler.rb
+++ b/bridgetown/handler.rb
@@ -2,6 +2,8 @@ require 'aws-sdk-s3'
 require 'aws-sdk-cloudfront'
 require 'bridgetown'
 require 'pathname'
+require 'bundler/setup'
+
 
 SITE_ROOT  = ENV['LAMBDA_TASK_ROOT']
 


### PR DESCRIPTION
- fix: remove old gemfile gitsource  code
- fix: run bundler setup
- fix: move bundler setup
- fix: move bundler/setup to handler script

<!-- auto generated content; do not edit this line and below -->
#### Changes to MAIN if this PR is merged:

<details>
<summary>Changes</summary>

```
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
Stack EnergyComparisonTableStack
There were no differences


```

</details>
