### PR TITLE
fix: copy lockfile

### DIFF
--- a/bridgetown/Dockerfile
+++ b/bridgetown/Dockerfile
@@ -3,7 +3,7 @@ FROM public.ecr.aws/lambda/ruby:3.2
 
 RUN yum -y groupinstall "Development Tools"
 # Copy Gemfile and Gemfile.lock
-COPY energy_tables/Gemfile ${LAMBDA_TASK_ROOT}/
+COPY energy_tables/Gemfile energy_tables/Gemfile.lock ${LAMBDA_TASK_ROOT}/
 
 
 # Install Bundler and the specified gems


### PR DESCRIPTION

<!-- auto generated content; do not edit this line and below -->
#### Changes to MAIN if this PR is merged:

<details>
<summary>Changes</summary>

```
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
Stack EnergyComparisonTableStack
Resources
[~] AWS::Lambda::Function Lambda LambdaD247545B 
 └─ [~] Code
     └─ [~] .ImageUri:
         └─ [~] .Fn::Join:
             └─ @@ -5,6 +5,6 @@
                [ ]     {
                [ ]       "Ref": "AWS::URLSuffix"
                [ ]     },
                [-]     "/cdk-hnb659fds-container-assets-979633842206-eu-west-1:9d5ba4d056ae4ea00126bafa0ffc5988fed220bd0ac27491a7f9c7e3174be108"
                [+]     "/cdk-hnb659fds-container-assets-979633842206-eu-west-1:e06e8667845040f35611fea3ceda8eb6ab5c075f35ce1eb2a02d5bcdd81292f9"
                [ ]   ]
                [ ] ]



```

</details>
