### PR TITLE
fix: freeze bundle so it does not write gemfile.lock

### DIFF
--- a/bridgetown/Dockerfile
+++ b/bridgetown/Dockerfile
@@ -8,6 +8,7 @@ COPY energy_tables/Gemfile energy_tables/Gemfile.lock ${LAMBDA_TASK_ROOT}/
 
 # Install Bundler and the specified gems
 RUN gem install bundler:2.4.14 && \
+    bundle config set --frozen && \
     bundle config set --local path 'vendor/bundle'
 
 RUN cd ${LAMBDA_TASK_ROOT} && bundle install


### PR DESCRIPTION

<!-- auto generated content; do not edit this line and below -->
#### Changes to MAIN if this PR is merged:

<details>
<summary>Changes</summary>

```
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
Stack EnergyComparisonTableStack
Resources
[~] AWS::Lambda::Function Lambda LambdaD247545B 
 └─ [~] Code
     └─ [~] .ImageUri:
         └─ [~] .Fn::Join:
             └─ @@ -5,6 +5,6 @@
                [ ]     {
                [ ]       "Ref": "AWS::URLSuffix"
                [ ]     },
                [-]     "/cdk-hnb659fds-container-assets-979633842206-eu-west-1:e06e8667845040f35611fea3ceda8eb6ab5c075f35ce1eb2a02d5bcdd81292f9"
                [+]     "/cdk-hnb659fds-container-assets-979633842206-eu-west-1:a063e909217ef6d3d34d541d1a8ec2e5a771b0fd7ff28d3aaf76fdb38be2b13b"
                [ ]   ]
                [ ] ]



```

</details>
