### PR TITLE
fix: revert docker file

### DIFF
--- a/bridgetown/Dockerfile
+++ b/bridgetown/Dockerfile
@@ -3,12 +3,11 @@ FROM public.ecr.aws/lambda/ruby:3.2
 
 RUN yum -y groupinstall "Development Tools"
 # Copy Gemfile and Gemfile.lock
-COPY energy_tables/Gemfile energy_tables/Gemfile.lock ${LAMBDA_TASK_ROOT}/
+COPY energy_tables/Gemfile ${LAMBDA_TASK_ROOT}/
 
 
 # Install Bundler and the specified gems
 RUN gem install bundler:2.4.14 && \
-    bundle config set --frozen && \
     bundle config set --local path 'vendor/bundle'
 
 RUN cd ${LAMBDA_TASK_ROOT} && bundle install


### PR DESCRIPTION

<!-- auto generated content; do not edit this line and below -->
#### Changes to MAIN if this PR is merged:

<details>
<summary>Changes</summary>

```
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.aws_lambda.EcrImageCodeProps#tag is deprecated.
  use `tagOrDigest`
  This API will be removed in the next major release.
Stack EnergyComparisonTableStack
There were no differences


```

</details>
