### PR TITLE
fix: old review app images not cleaned up from ECR

### DIFF
--- a/.github/workflows/review-app-create.yml
+++ b/.github/workflows/review-app-create.yml
@@ -11,7 +11,7 @@ concurrency:
 env:
   NAMESPACE: review-${{ github.event.pull_request.number }}-energy-comparison-table
   HOST_NAME: review-${{ github.event.pull_request.number }}-energy-comparison-table.qa.citizensadvice.org.uk
-  IMAGE_TAG: ${{ github.sha }}
+  IMAGE_TAG: dev_${{ github.sha }}
   CLUSTER: dev-eks-platform
 
 jobs:


### PR DESCRIPTION
There's an ECR lifecycle rule to delete old dev images after 3 months - https://github.com/citizensadvice/energy-comparison-table/blob/fe9ca84a73d879a53eb091e4dcf11e40bcc94ea6/infrastructure/stacks/ecr.py#L24

The rule wasn't picking up the review app images as they weren't tagged correctly