### PR TITLE
GitHub actions tweaks

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -10,18 +10,18 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v3
 
+      - name: "Setup ruby"
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
       - name: "Setup node"
         uses: actions/setup-node@v3
         with:
           node-version-file: .nvmrc
 
       - name: "Install npm packages"
-        run: yarn install
-
-      - name: "Setup ruby"
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
+        uses: bahmutov/npm-install@v1
 
       - name: "Node lint"
         run: yarn run lint
@@ -43,6 +43,14 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+
+      - name: "Setup node"
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+
+      - name: "Install npm packages"
+        uses: bahmutov/npm-install@v1
 
       - name: "Precompile assets"
         run: bundle exec rails assets:precompile


### PR DESCRIPTION
👋 One more small drive-by PR that I noticed whilst updating things in https://github.com/citizensadvice/energy-comparison-table/pull/51.

## Use bundler-cache when installing gems

Now that #39 has added extra platforms to the gemfile the actions config can use the standard ruby action config to install (and importantly cache) the bundle install step. This should shave some time off subsequent CI runs.

As a result updates bundler-audit to be run via `bundle exec bundler-audit` to ensure it's run in the project context.

## Use built in rubocop github formatter

Recent versions of rubocop include a github actions formatter which should avoid the need for the extra action. This is ported across from the great work @nehanakrani did on the casebook version of these actions checks.

Included a screenshot showing some failing rubocop warnings included to test this. See (https://github.com/citizensadvice/energy-comparison-table/pull/52/commits/e7324e2be75000a7a884ecfeacd7e48bc67d3995)

<img width="1094" alt="image" src="https://github.com/citizensadvice/energy-comparison-table/assets/123386/d4ab0e32-4cb2-4a7d-b058-6a76be411b6f">

## Explicitly install node during CI tests

The CI test step previously didn't explicitly install node as part of the test step.

The `bundle exec rails assets:precompile` step will attempt to run `yarn install` if it's not been run before so this technically worked but the dependency step was actually running against the actions installed version of node (Node.js 18.17.0 on Ubuntu 22.04) rather than the project version.

Adding an explicit install step to avoid any confusing behaviour.

Uses bahmutov/npm-install to make use of the cache for npm dependencies too.