### PR TITLE
chart: make it possible to set env vars

### DIFF
--- a/infrastructure/chart/energy-comparison-table/templates/deployment.yaml
+++ b/infrastructure/chart/energy-comparison-table/templates/deployment.yaml
@@ -33,6 +33,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          {{- range $name, $val := .Values.envVars }}
+            - name: {{ $name }}
+              value: {{ $val }}
+          {{ end -}}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/infrastructure/chart/energy-comparison-table/values.yaml
+++ b/infrastructure/chart/energy-comparison-table/values.yaml
@@ -10,6 +10,8 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "main"
 
+envVars: {}
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
adds the ability to set env vars in the chart configuration.

Adding the env vars will be done separately