### PR TITLE
fix: dont use css digest in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,6 +46,7 @@ Rails.application.configure do
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true
+  config.assets.digest = false
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true


### PR DESCRIPTION
Adds asset config so that the CSS digest isn't added into the application CSS link