### PR TITLE
pass all GH secrets to helm

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -62,14 +62,18 @@ jobs:
         run: aws eks update-kubeconfig --name=${{ env.EKS_CLUSTER }}
       - name: Helm Deploy
         run: |
+          cat > secrets_${{matrix.stage}}.json << EOF
+          {
+            "secrets":  ${{toJson(secrets)}}
+          }
+          EOF
+
           helm upgrade --install \
           --namespace=${{matrix.stage}}-energy-comparison-table \
           --values energy-comparison-table/infrastructure/app/stages/${{matrix.stage}}.yaml \
+          --values secrets_${{matrix.stage}}.json \
           --set image.repository=979633842206.dkr.ecr.eu-west-1.amazonaws.com/energy-comparison-table \
           --set image.tag=${{ env.IMAGE_TAG }} \
           --set ingress.hostname=energy-comparison-table.${{env.HOSTED_ZONE}} \
-          --set secrets.CONTENTFUL_CDA_TOKEN=${{ secrets.CONTENTFUL_CDA_TOKEN }} \
-          --set secrets.CONTENTFUL_SPACE_ID=${{ secrets.CONTENTFUL_SPACE_ID }} \
-          --set secrets.CONTENTFUL_ENVIRONMENT_ID=${{ secrets.CONTENTFUL_ENVIRONMENT_ID }} \
           ${{matrix.stage}}-energy-comparison-table \
           energy-comparison-table/infrastructure/app/chart/energy-comparison-table

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -24,7 +24,7 @@ Stage (environment) specific env vars can be set in the stage-specific helm over
 
 - secrets
 
-Secrets are set in GH for each environment. To be used by the deployment, secrets have to be explicitly referenced in the helm deployment action
+Secrets set in GH environments are automatically passed to the helm chart which deploys them as a K8s secret.
 
 ## Deployment
 


### PR DESCRIPTION
to streamline the process a bit. Maybe we can do the same with plain env vars but `env` contains user-provided as well as GH specific env vars.