### PR TITLE
Feat/supplier table page layout

### DIFF
--- a/app/components/location_switcher_component.html.haml
+++ b/app/components/location_switcher_component.html.haml
@@ -1,0 +1,6 @@
+.location-switcher
+  %p.location-switcher__text
+    = "This advice applies to #{localised_current_country}. "
+    %span.location-switcher__alternative-locations
+      = "See advice for"
+      = country_links

--- a/app/components/location_switcher_component.rb
+++ b/app/components/location_switcher_component.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class LocationSwitcherComponent < ViewComponent::Base
+  attr_reader :current_country
+
+  def initialize(current_country:)
+    super
+
+    @current_country = current_country
+    @available_country_urls = available_country_urls
+  end
+
+  def localised_current_country
+    localise_country(current_country)
+  end
+
+  def country_urls
+    @available_country_urls.reject { |country| country == current_country }
+  end
+
+  def country_links
+    links = country_urls.map do |country, url|
+      link_to url, class: "location-switcher__link" do
+        tag.span("See advice for ", class: "cads-sr-only") + localise_country(country)
+      end
+    end
+    safe_join(links, ", ")
+  end
+
+  def render?
+    @available_country_urls.present?
+  end
+
+  private
+
+  def localise_country(country)
+    {
+      england: "England",
+      scotland: "Scotland",
+      wales: "Wales"
+    }.fetch(country.to_sym, country.titleize)
+  end
+
+  def available_country_urls
+    {
+      "england" => "/consumer/your-energy/get-a-better-energy-deal/compare-domestic-energy-suppliers-customer-service/",
+      "scotland" => "/scotland/consumer/your-energy/get-a-better-energy-deal/compare-domestic-energy-suppliers-customer-service/",
+      "wales" => "/wales/consumer/your-energy/get-a-better-energy-deal/compare-domestic-energy-suppliers-customer-service/"
+    }
+  end
+end

--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -15,7 +15,7 @@ class SuppliersController < ApplicationController
     ranked_suppliers = @suppliers.select(&:ranked?)
     unranked_suppliers = @suppliers.reject(&:ranked?)
 
-    render "index", locals: { ranked_suppliers:, unranked_suppliers: }
+    render "index", locals: { ranked_suppliers:, unranked_suppliers:, current_country: }
   end
 
   def show; end

--- a/app/views/suppliers/index.html.haml
+++ b/app/views/suppliers/index.html.haml
@@ -1,15 +1,17 @@
-%h1.cads-page-title
-  Energy Supplier Comparison Table
+%main.cads-page-content
+  %h1.cads-page-title
+    Energy Supplier Comparison Table
 
-.cads-prose
-  %h2 Ranked suppliers
-  %ol
-    - ranked_suppliers.each do |supplier|
-      %li
-        = link_to("#{supplier.name}, overall rating: #{supplier.overall_rating}", supplier)
+  = render(LocationSwitcherComponent.new(current_country: current_country))
+  .cads-prose
+    %h2 Ranked suppliers
+    %ol
+      - ranked_suppliers.each do |supplier|
+        %li
+          = link_to("#{supplier.name}, overall rating: #{supplier.overall_rating}", supplier)
 
-  %h2 Unranked suppliers
-  %ul
-    - unranked_suppliers.each do |supplier|
-      %li
-        = link_to(supplier.name, supplier)
+    %h2 Unranked suppliers
+    %ul
+      - unranked_suppliers.each do |supplier|
+        %li
+          = link_to(supplier.name, supplier)

--- a/spec/components/location_switcher_component_spec.rb
+++ b/spec/components/location_switcher_component_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LocationSwitcherComponent, type: :component do
+  subject { page }
+
+  before do
+    render_inline described_class.new(
+      current_country:
+    )
+  end
+
+  context "when current country is england" do
+    let(:current_country) { "england" }
+
+    it { is_expected.to have_text "This advice applies to England" }
+    it { is_expected.to have_link "a", text: "See advice for Scotland" }
+    it { is_expected.to have_link "a", text: "See advice for Wales" }
+    it { is_expected.not_to have_link "a", text: "See advice for England" }
+  end
+
+  context "when current country is scotland" do
+    let(:current_country) { "scotland" }
+
+    it { is_expected.to have_text "This advice applies to Scotland" }
+    it { is_expected.to have_link "a", text: "See advice for England" }
+    it { is_expected.to have_link "a", text: "See advice for Wales" }
+    it { is_expected.not_to have_link "a", text: "See advice for Scotland" }
+  end
+
+  context "when current country is wales" do
+    let(:current_country) { "wales" }
+
+    it { is_expected.to have_text "This advice applies to Wales" }
+    it { is_expected.to have_link "a", text: "See advice for England" }
+    it { is_expected.to have_link "a", text: "See advice for Scotland" }
+    it { is_expected.not_to have_link "a", text: "See advice for Wales" }
+  end
+end


### PR DESCRIPTION
Surrounding text for supplier table itself to be hard-coded for the MVP.

This PR adds:
- location_switcher_component