### PR TITLE
fix: change APP_PATH var name

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,15 +23,15 @@ end
 # the path below.
 # If the dummy page entry that represents this app is moved in Contentful, this url will need to be updated,
 # a redirect added in Contentful, and the CloudFront config changed to reflect the new url.
-APP_PATH = "/consumer/your-energy/get-a-better-energy-deal/compare-domestic-energy-suppliers-customer-service/"
+CSR_APP_PATH = "/consumer/your-energy/get-a-better-energy-deal/compare-domestic-energy-suppliers-customer-service/"
 
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   constraints CountryConstraint.new do
     scope "(:country)" do
-      get APP_PATH, to: "suppliers#index", as: "suppliers"
-      get "#{APP_PATH}/:id", to: "suppliers#show", as: "supplier"
+      get CSR_APP_PATH, to: "suppliers#index", as: "suppliers"
+      get "#{CSR_APP_PATH}/:id", to: "suppliers#show", as: "supplier"
     end
   end
 

--- a/spec/requests/suppliers_spec.rb
+++ b/spec/requests/suppliers_spec.rb
@@ -9,31 +9,31 @@ RSpec.describe "Suppliers" do
 
   context "when no country is specified" do
     it "responds successfully to the suppliers route" do
-      get APP_PATH # defined in routes.rb
+      get CSR_APP_PATH # defined in routes.rb
 
       expect(response).to have_http_status :successful
     end
 
     it "render the switftype search type advice metatag" do
-      get APP_PATH
+      get CSR_APP_PATH
 
       expect(response.body).to include("<meta class='swiftype' content='advice' data-type='string' name='search_type_filter'>")
     end
 
     it "render the switftype search type everything metatag" do
-      get APP_PATH
+      get CSR_APP_PATH
 
       expect(response.body).to include("<meta class='swiftype' content='everything' data-type='string' name='search_type_filter'>")
     end
 
     it "render the switftype audience england metatag" do
-      get APP_PATH
+      get CSR_APP_PATH
 
       expect(response.body).to include("<meta class='swiftype' content='england' data-type='string' name='audience_filter'>")
     end
 
     it "responds successfully to the supplier detail route" do
-      get "#{APP_PATH}/an-energy-supplier"
+      get "#{CSR_APP_PATH}/an-energy-supplier"
 
       expect(response).to have_http_status :successful
     end
@@ -41,13 +41,13 @@ RSpec.describe "Suppliers" do
 
   context "when the country is Scotland" do
     it "responds successfully to the suppliers route" do
-      get "/scotland/#{APP_PATH}"
+      get "/scotland/#{CSR_APP_PATH}"
 
       expect(response).to have_http_status :successful
     end
 
     it "responds successfully to the supplier detail route" do
-      get "/scotland/#{APP_PATH}/an-energy-supplier"
+      get "/scotland/#{CSR_APP_PATH}/an-energy-supplier"
 
       expect(response).to have_http_status :successful
     end
@@ -55,19 +55,19 @@ RSpec.describe "Suppliers" do
 
   context "when the country is Wales" do
     it "responds successfully to the suppliers route" do
-      get "/wales/#{APP_PATH}"
+      get "/wales/#{CSR_APP_PATH}"
 
       expect(response).to have_http_status :successful
     end
 
     it "responds successfully to the supplier detail route" do
-      get "/wales/#{APP_PATH}/an-energy-supplier"
+      get "/wales/#{CSR_APP_PATH}/an-energy-supplier"
 
       expect(response).to have_http_status :successful
     end
 
     it "renders the switftype meta tags" do
-      get "/wales/#{APP_PATH}"
+      get "/wales/#{CSR_APP_PATH}"
 
       expect(response.body).to include("<meta class='swiftype' content='wales' data-type='string' name='audience_filter'>")
     end
@@ -75,13 +75,13 @@ RSpec.describe "Suppliers" do
 
   context "when an invalid country is requested" do
     it "responds successfully to the suppliers route" do
-      get "/france/#{APP_PATH}"
+      get "/france/#{CSR_APP_PATH}"
 
       expect(response).to have_http_status :not_found
     end
 
     it "responds successfully to the supplier detail route" do
-      get "/france/#{APP_PATH}/an-energy-supplier"
+      get "/france/#{CSR_APP_PATH}/an-energy-supplier"
 
       expect(response).to have_http_status :not_found
     end


### PR DESCRIPTION
APP_PATH is actually used in `bin/rails` so we need to change the name of our variable to avoid a conflict