### PR TITLE
fix: run rails in production mode in qa and prod envs

### DIFF
--- a/infrastructure/app/stages/dev.yaml
+++ b/infrastructure/app/stages/dev.yaml
@@ -16,3 +16,6 @@ annotations:
       {"schedule": "30 18 * * Mon-Fri", "replicas": "0", "tz": "Europe/London"},
       {"schedule": "40 7 * * Mon-Fri", "replicas": "1", "tz": "Europe/London"}
     ]
+
+envVars:
+  RAILS_ENV: production

--- a/infrastructure/app/stages/prod.yaml
+++ b/infrastructure/app/stages/prod.yaml
@@ -9,3 +9,6 @@ ingress:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/healthcheck-path: /status
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+
+envVars:
+  RAILS_ENV: production


### PR DESCRIPTION
Run rails in production mode in the `qa` and `prod` environments.