### PR TITLE
feat: use normal render method for fuel mix

### DIFF
--- a/app/components/other_info_component.rb
+++ b/app/components/other_info_component.rb
@@ -40,6 +40,6 @@ class OtherInfoComponent < ViewComponent::Base
   end
 
   def fuel_mix
-    renderer.render_with_breaks(supplier.fuel_mix)
+    renderer.render_without_breaks(supplier.fuel_mix)
   end
 end

--- a/app/lib/renderers/rich_text_renderer.rb
+++ b/app/lib/renderers/rich_text_renderer.rb
@@ -10,5 +10,14 @@ module Renderers
       render(node.json).gsub("\n", "<br/>").html_safe
       # rubocop:enable Rails/OutputSafety
     end
+
+    def render_without_breaks(node)
+      return if node.blank?
+
+      # We can trust content from Contentful
+      # rubocop:disable Rails/OutputSafety
+      render(node.json).html_safe
+      # rubocop:enable Rails/OutputSafety
+    end
   end
 end


### PR DESCRIPTION
Uses the normal `render` method for fuel mix, which now has `ul` and `p` elements in the designs, so we don't need to use `br` like we do in the other info sections.