### PR TITLE
feat: add dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,25 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+    groups:
+      js-dependencies:
+        patterns:
+          - '@babel/*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      testing-dependencies:
+        patterns:
+          - '@typescript-eslint/*'
+          - 'eslint*'
+          - 'stylelint*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      patch-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - 'patch'
     ignore:
       - dependency-name: '@citizensadvice/design-system'


### PR DESCRIPTION
Initial attempt to add groups to dependabot updates configuration. 

I used the dependabot groups from public website as the start point, removing any packages that we didn't also have on energy comparison table.

Looking at the dependabot updates triggered over the last couple of weeks there didn't yet appear to be patterns suggesting that we would need specific additional groups, but this can be tweaked in the future if patterns emerge.