### PR TITLE
feat: change ingress hostname to cdn

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -74,7 +74,7 @@ jobs:
           --values secrets_${{matrix.stage}}.json \
           --set image.repository=979633842206.dkr.ecr.eu-west-1.amazonaws.com/energy-comparison-table \
           --set image.tag=${{ env.IMAGE_TAG }} \
-          --set ingress.hostname=energy-comparison-table.${{env.HOSTED_ZONE}} \
+          --set ingress.hostname=cdn.${{env.HOSTED_ZONE}} \
           --atomic \
           --timeout 15m \
           ${{matrix.stage}}-energy-comparison-table \


### PR DESCRIPTION
When we add energy-comparison-table.qa.citizensadvice.org.uk to CloudFront as a new origin in the QA environment, the ALB returns 404 responses.  This commit sets the hostname to cdn.qa.citizensadvice.org.uk so that requests will be forwarded to the correct target group.