### PR TITLE
[OPS-5390] Use ca-constructs ECR repository

### DIFF
--- a/infrastructure/cdk/poetry.lock
+++ b/infrastructure/cdk/poetry.lock
@@ -77,6 +77,24 @@ publication = ">=0.0.3"
 typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
+name = "aws-cdk-lambda-layer-kubectl-v27"
+version = "2.0.0"
+description = "A Lambda Layer that contains kubectl v1.27"
+optional = false
+python-versions = "~=3.7"
+files = [
+    {file = "aws-cdk.lambda-layer-kubectl-v27-2.0.0.tar.gz", hash = "sha256:eda4078c3c0c7a158c60ead83c410a1649839009e6636c613098c26319c6fa14"},
+    {file = "aws_cdk.lambda_layer_kubectl_v27-2.0.0-py3-none-any.whl", hash = "sha256:61b5c675ab24afef28be4f38ba2d7d77eee711019223483579e0aec3648fca9b"},
+]
+
+[package.dependencies]
+aws-cdk-lib = ">=2.28.0,<3.0.0"
+constructs = ">=10.0.5,<11.0.0"
+jsii = ">=1.84.0,<2.0.0"
+publication = ">=0.0.3"
+typeguard = ">=2.13.3,<2.14.0"
+
+[[package]]
 name = "aws-cdk-lib"
 version = "2.90.0"
 description = "Version 2 of the AWS Cloud Development Kit library"
@@ -95,6 +113,28 @@ constructs = ">=10.0.0,<11.0.0"
 jsii = ">=1.86.0,<2.0.0"
 publication = ">=0.0.3"
 typeguard = ">=2.13.3,<2.14.0"
+
+[[package]]
+name = "ca-cdk-constructs"
+version = "0.7.0"
+description = "Shared CDK constructs"
+optional = false
+python-versions = "^3.10"
+files = []
+develop = false
+
+[package.dependencies]
+aws-cdk-lambda-layer-kubectl-v27 = "^2.0.0"
+aws-cdk-lib = "~=2.77"
+cdk_remote_stack = "~=2.0"
+cdk8s-plus-26 = "~=2.3"
+constructs = "~=10.1"
+
+[package.source]
+type = "git"
+url = "https://github.com/citizensadvice/ca-cdk-constructs"
+reference = "v0.7.0"
+resolved_reference = "a6ef60522b5bd1116792f5156b3caced1a623bff"
 
 [[package]]
 name = "cattrs"
@@ -118,6 +158,59 @@ orjson = ["orjson (>=3.5.2,<4.0.0)"]
 pyyaml = ["PyYAML (>=6.0,<7.0)"]
 tomlkit = ["tomlkit (>=0.11.4,<0.12.0)"]
 ujson = ["ujson (>=5.4.0,<6.0.0)"]
+
+[[package]]
+name = "cdk-remote-stack"
+version = "2.0.101"
+description = "Get outputs and AWS SSM parameters from cross-region AWS CloudFormation stacks"
+optional = false
+python-versions = "~=3.7"
+files = [
+    {file = "cdk-remote-stack-2.0.101.tar.gz", hash = "sha256:0a43ec97e02bd2a021993fd8c9c48b2f29dfbe26e214649d099455cde0e38c89"},
+    {file = "cdk_remote_stack-2.0.101-py3-none-any.whl", hash = "sha256:5577af4f854a628a57e448b1b77c1eac55de55bc5e8d1c135a8781046bddd5ab"},
+]
+
+[package.dependencies]
+aws-cdk-lib = ">=2.0.0,<3.0.0"
+constructs = ">=10.0.5,<11.0.0"
+jsii = ">=1.90.0,<2.0.0"
+publication = ">=0.0.3"
+typeguard = ">=2.13.3,<2.14.0"
+
+[[package]]
+name = "cdk8s"
+version = "2.67.2"
+description = "This is the core library of Cloud Development Kit (CDK) for Kubernetes (cdk8s). cdk8s apps synthesize into standard Kubernetes manifests which can be applied to any Kubernetes cluster."
+optional = false
+python-versions = "~=3.7"
+files = [
+    {file = "cdk8s-2.67.2-py3-none-any.whl", hash = "sha256:d3a0b672b576c7c71d93f3b16b6861c4a491e5e2cdab617498346521a69f9885"},
+    {file = "cdk8s-2.67.2.tar.gz", hash = "sha256:67c8194a149f2cd4112c79f5b7e3bc149226ee8416e84d874a64a60053286030"},
+]
+
+[package.dependencies]
+constructs = ">=10.0.0,<11.0.0"
+jsii = ">=1.90.0,<2.0.0"
+publication = ">=0.0.3"
+typeguard = ">=2.13.3,<2.14.0"
+
+[[package]]
+name = "cdk8s-plus-26"
+version = "2.18.45"
+description = "cdk8s+ is a software development framework that provides high level abstractions for authoring Kubernetes applications. cdk8s-plus-26 synthesizes Kubernetes manifests for Kubernetes 1.26.0"
+optional = false
+python-versions = "~=3.7"
+files = [
+    {file = "cdk8s-plus-26-2.18.45.tar.gz", hash = "sha256:ca4676bc55704daa937043ddaa3eeea60552b055de05db6bfaa7feb2b043a23d"},
+    {file = "cdk8s_plus_26-2.18.45-py3-none-any.whl", hash = "sha256:a921819a70ade42f56c906468c3b7fdb0b9adc989328c265a856047ee87d8ce8"},
+]
+
+[package.dependencies]
+cdk8s = ">=2.67.1,<3.0.0"
+constructs = ">=10.3.0,<11.0.0"
+jsii = ">=1.90.0,<2.0.0"
+publication = ">=0.0.3"
+typeguard = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "cfgv"
@@ -514,4 +607,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11, <3.12"
-content-hash = "abbab00c9a553e6debede40b95f22a3e9cefa7c487d7dccf8e3f49b7da7e6bf3"
+content-hash = "8dbbbcee423c1c96ed19f1fb53c87f98390ac11f7e8a93b304c54ec85c72afb5"

--- a/infrastructure/cdk/pyproject.toml
+++ b/infrastructure/cdk/pyproject.toml
@@ -10,6 +10,7 @@ python = ">=3.11, <3.12"
 aws-cdk-lib = "2.90.0"
 constructs = ">=10.0.0,<11.0.0"
 pytest = "6.2.5"
+ca-cdk-constructs = {git = "https://github.com/citizensadvice/ca-cdk-constructs", rev = "v0.7.0"}
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "2.20.0"

--- a/infrastructure/cdk/stacks/ecr.py
+++ b/infrastructure/cdk/stacks/ecr.py
@@ -1,8 +1,9 @@
 from typing import Sequence
-from aws_cdk import Duration, RemovalPolicy, Stack
-from aws_cdk.aws_ecr import LifecycleRule, Repository, TagStatus
+from aws_cdk import RemovalPolicy, Stack
+from aws_cdk.aws_ecr import Repository
 from aws_cdk.aws_iam import IPrincipal
 from constructs import Construct
+from ca_cdk_constructs.ecr.ecr_repository import ECRRepository
 
 
 class EcrRepository(Stack):
@@ -15,27 +16,11 @@ class EcrRepository(Stack):
     ) -> None:
         super().__init__(scope, id, **kwargs)
 
-        repo = Repository(
-            self,
-            "Default",
-            removal_policy=RemovalPolicy.DESTROY,
-            auto_delete_images=True,
-            image_scan_on_push=True,
-            repository_name="energy-comparison-table",
-            lifecycle_rules=[
-                LifecycleRule(
-                    description="Delete untagged images",
-                    max_image_age=Duration.days(3),
-                    tag_status=TagStatus.UNTAGGED,
-                    rule_priority=1,
-                ),
-                LifecycleRule(
-                    description="Delete dev images",
-                    max_image_age=Duration.days(30 * 3),
-                    tag_prefix_list=["dev_"],
-                    rule_priority=2,
-                ),
-            ],
-        )
+        repo: Repository = ECRRepository(
+            self, "Default", name="energy-comparison-table"
+        ).repository
+
+        repo.apply_removal_policy(RemovalPolicy.DESTROY)
+
         for principal in pull_principals:
             repo.grant_pull(principal)


### PR DESCRIPTION
Use the `ca-cdk-constructs` ECR repository to standardise around the same set of lifecycle rules.

See: https://citizensadvice.atlassian.net/browse/OPS-5390