### PR TITLE
feat: scope asset dir to this app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 .idea
 
 /public/assets
+/public/energy-csr-assets
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,3 +14,4 @@ Rails.application.config.assets.version = "1.0"
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
 Rails.application.config.assets.paths << Rails.root.join("node_modules/@citizensadvice/design-system/assets/")
+Rails.application.config.assets.prefix = "/energy-csr-assets"


### PR DESCRIPTION
Scopes the path of the front end assets to something different (`/energy-csr-assets`) from the default one taken by public website (`/assets`)