### PR TITLE
feat: add lang attribute to html tag

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html.no-js
+%html.no-js{ lang: I18n.locale }
   %head
     %meta{ content: "text/html; charset=UTF-8", "http-equiv": "Content-Type" }
     %meta{ content: "width=device-width,initial-scale=1", name: "viewport" }


### PR DESCRIPTION
Missing lang attribute identified by AbilityNet during accessibility review. 