### PR TITLE
fix: enable horiztonal pod autoscaling

### DIFF
--- a/infrastructure/app/chart/energy-comparison-table/values.yaml
+++ b/infrastructure/app/chart/energy-comparison-table/values.yaml
@@ -41,7 +41,8 @@ podSecurityContext:
   runAsGroup: 3000
   fsGroup: 3000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -59,7 +60,8 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -72,9 +74,9 @@ resources: {}
   #   memory: 128Mi
 
 autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 8
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 


### PR DESCRIPTION
Enables horiztonal pod autoscaling for the energy comparison table app