### PR TITLE
fix: hpa yaml for autoscaling/v2

### DIFF
--- a/infrastructure/app/chart/energy-comparison-table/templates/hpa.yaml
+++ b/infrastructure/app/chart/energy-comparison-table/templates/hpa.yaml
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+          target:
+            type: Utilization
+            averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Updates the `hpa.yaml` file in line with `autoscaler/v2` metrics specs

Fixes https://github.com/citizensadvice/energy-comparison-table/actions/runs/7197762983/job/19605690650#step:6:43