### PR TITLE
Feat: add aria-labelledby tag to 'More details' links

### DIFF
--- a/app/components/supplier_table_row_component.html.haml
+++ b/app/components/supplier_table_row_component.html.haml
@@ -3,7 +3,7 @@
     %span.cads-table__content
       = supplier.rank
   %td.supplier-table__name
-    %span.cads-table__content{ id: supplier.name }
+    %span.cads-table__content
       = supplier.name
   %td.supplier-table__complaints
     %span.cads-table__content


### PR DESCRIPTION
Addresses ADR_19364-4 MEDIUM PRIORITY from [AbilityNet accessibility review](https://drive.google.com/file/d/1V6ZGHdse7TLIKKf9CinA38oXAJCQd-kr/view?usp=sharing). 

Adds an `aria-labelledby` attribute to 'More details' links, so that a screen reader would read them as 'More details on <energy supplier>' rather than just 'More details'.