### PR TITLE
Set focus for "on this page" links

### DIFF
--- a/app/components/other_info_component.rb
+++ b/app/components/other_info_component.rb
@@ -17,7 +17,7 @@ class OtherInfoComponent < ViewComponent::Base
   def descriptions
     [
       {
-        term: content_tag(:h2, "Customer service contact details for #{supplier.name}", { id: contact_details_fragment }),
+        term: content_tag(:h2, "Customer service contact details for #{supplier.name}", { id: contact_details_fragment, tabindex: -1 }),
         description: contact_info
       },
       {

--- a/app/components/other_scores_component.html.haml
+++ b/app/components/other_scores_component.html.haml
@@ -1,7 +1,7 @@
 .cads-grid-row
   .cads-grid-col-md-9
     .other-scores
-      %h2{ id: scores_fragment } Other scores
+      %h2{ id: scores_fragment, tabindex: -1 } Other scores
       .other-scores__descriptions
         = render DescriptionListComponent.new do |c|
           - c.with_descriptions(descriptions)


### PR DESCRIPTION
To address issue ADR_19364-11 identified by AbilityNet in [their accessibility review](https://drive.google.com/file/d/1V6ZGHdse7TLIKKf9CinA38oXAJCQd-kr/view).

AbilityNet observed that, for a screenreader user on Mobile(iOS), the links in the 'On this page' section were not correctly setting focus to 'Other scores' and 'Other info' section headings.  

Steps to reproduce:
1. Observe the same page links.
2. Navigate onto the links with a screen reader enabled.
3. Activate the link.
4. Observe that the screen reader cursor is set incorrectly to the skip link.

Note that this problem does not affect screenreader users on desktop(macOS), and so I have been unable to replicate the issue.

Visiting the supplier details page on [qa](https://energy-comparison-table.qa.citizensadvice.org.uk/consumer/your-energy/get-a-better-energy-deal/compare-domestic-energy-suppliers-customer-service/shell-energy/details) from an iPhone should allow the reviewer to replicate the issue.

Visiting a supplier details page on the review app for this PR from an iPhone should allow the reviewer to test the fix.