### PR TITLE
Feat: keep focus on more/fewer suppliers button

### DIFF
--- a/app/javascript/supplier-table.js
+++ b/app/javascript/supplier-table.js
@@ -33,6 +33,8 @@ const showMoreSuppliers = () => {
 
   updateCountText(totalRows);
   showRows();
+  const showFewer = document.querySelector(selectors.showFewerButton);
+  showFewer.focus({ focusVisible: true });
 };
 
 const showFewerSuppliers = () => {
@@ -42,6 +44,8 @@ const showFewerSuppliers = () => {
 
   updateCountText(5);
   hideRows();
+  const showMore = document.querySelector(selectors.showMoreButton);
+  showMore.focus({ focusVisible: true });
 };
 
 const addButtonEventHandlers = () => {


### PR DESCRIPTION
Resolves issue ADR_19364-9 identified by AbilityNet in their [accessibility review](https://drive.google.com/file/d/1V6ZGHdse7TLIKKf9CinA38oXAJCQd-kr/view).

AbilityNet observed that, for a keyboard user on mobile (iOS) focus was not logically set after clicking on the 'Show more suppliers' and 'Show fewer suppliers' buttons. Clicking on 'Show more suppliers' moved focus to row 6 of the now-expanded supplier table, while clicking on 'Show fewer suppliers' moved focus to the impact survey link.

Steps to reproduce:
1. Using just your keyboard, tab onto the above elements and activate them.
2. Observe that keyboard focus does not remain on the element.
3. Observe that users are not warned about this behaviour beforehand.
4. Observe that it is not reasonable for users to expect this behaviour.
5. Observe that keyboard focus is not sent to a logical place on the page.

Focus now amended so that:
- clicking on 'Show more suppliers' moves focus to the now visible 'Show fewer suppliers' button
- clicking on 'Show fewer suppliers' moves focus to the now visible 'Show more suppliers' button