### PR TITLE
feat: add meta descriptions

### DIFF
--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -87,9 +87,11 @@ class SuppliersController < ApplicationController
 
   def meta_description
     # rubocop:disable Layout/LineLength
-    return "Don’t switch before you compare customer services. Large energy companies ranked by number of complaints, wait times and commitments. Check your supplier." if supplier.blank?
-
-    "Customer service contact details and scores for #{supplier.name}. Find out how well #{supplier.name} customer service performs and how to contact them."
+    if supplier.blank?
+      "Don’t switch before you compare customer services. Large energy companies ranked by number of complaints, wait times and commitments. Check your supplier."
+    else
+      "Customer service contact details and scores for #{supplier.name}. Find out how well #{supplier.name} customer service performs and how to contact them."
+    end
     # rubocop:enable Layout/LineLength
   end
 

--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -71,6 +71,7 @@ class SuppliersController < ApplicationController
 
     set_meta_tags(
       title: meta_title,
+      description: meta_description,
       icon: [
         { href: "/static/layout/favicon.ico" },
         { href: "/static/images/apple-touch-icon.png", rel: "apple-touch-icon", type: "image/png" }
@@ -82,6 +83,14 @@ class SuppliersController < ApplicationController
     return "Compare energy suppliers' customer service" if supplier.blank?
 
     "#{supplier.name} customer service performance"
+  end
+
+  def meta_description
+    # rubocop:disable Layout/LineLength
+    return "Don’t switch before you compare customer services. Large energy companies ranked by number of complaints, wait times and commitments. Check your supplier." if supplier.blank?
+
+    "Customer service contact details and scores for #{supplier.name}. Find out how well #{supplier.name} customer service performs and how to contact them."
+    # rubocop:enable Layout/LineLength
   end
 
   def custom_data_layer_properties


### PR DESCRIPTION
Adds meta descriptions, as defined in the content design google docs for the [main table page](https://docs.google.com/document/d/1iArgov3r8PZA8uxH_7oLO_b8a5scUUoUUNgqD23pYDw/edit) and [supplier detail page](https://docs.google.com/document/d/1ifMho6ovQlzQloFhEQhjMRwLcMsNTRUJwB7_4iVkxFA/edit).

Main table page meta description:

> Don’t switch before you compare customer services. Large energy companies ranked by number of complaints, wait times and commitments. Check your supplier.

Supplier detail page meta description:

> Customer service contact details and scores for _supplier_name_. Find out how well _supplier_name_ customer service performs and how to contact them.