### PR TITLE
Add page GUID to pages

### DIFF
--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -99,12 +99,14 @@ class SuppliersController < ApplicationController
     if supplier.blank?
       {
         pageTemplate: "Energy Customer Service Ratings Table",
-        pageType: "Energy Customer Service Ratings Table"
+        pageType: "Energy Customer Service Ratings Table",
+        GUID: "energy-csr-table"
       }
     else
       {
         pageTemplate: "Energy Customer Service Ratings - #{supplier.name}",
-        pageType: "Energy Customer Service Ratings - #{supplier.name}"
+        pageType: "Energy Customer Service Ratings - #{supplier.name}",
+        GUID: "energy-csr-#{supplier.slug}"
       }
     end
   end


### PR DESCRIPTION
The Data team use page GUID to report on page views for advice content. Currently pages in the energy CSR table don’t have page GUIDs, so we need to add them.

In `public-website` we use either the Episerver ID or Contentful ID as `GUID`. However, since the pages for the Energy CSR table don't exist as such in Contentful I have instead used:
- `energy-csr-table` as the `GUID` for the main comparison table page
- `energy-csr-#{slug}` as the `GUID` for the individual supplier detail pages.

`slug` is a unique field for the `energySupplier` content type in Contentful.