### PR TITLE
feat: horizontal scrolling table

### DIFF
--- a/app/components/supplier_table_component.html.haml
+++ b/app/components/supplier_table_component.html.haml
@@ -8,6 +8,9 @@
         %th{ scope: "col" }
           %span.cads-table__content
             Supplier
+        %th{ scope: "col" }
+          %span.cads-table__content
+            Overall rating
         %th.supplier-table__complaints{ scope: "col" }
           %span.cads-table__content
             Fewer complaints received
@@ -17,12 +20,6 @@
         %th.supplier-table__guarantee{ scope: "col" }
           %span.cads-table__content
             Customer commitments
-        %th{ scope: "col" }
-          %span.cads-table__content
-            %span.cads-hide-md-up
-              Rating
-            %span.cads-show-md-up
-              Overall rating
     %tbody.supplier-table__body
       - suppliers.each do |supplier|
         = render SupplierTableRowComponent.new(supplier, highlight: supplier.slug == highlight_supplier_with_slug, current_country:)

--- a/app/components/supplier_table_row_component.html.haml
+++ b/app/components/supplier_table_row_component.html.haml
@@ -5,6 +5,9 @@
   %td.supplier-table__name
     %span.cads-table__content
       = supplier.name
+  %td
+    %span.cads-table__content
+      = render_overall_score
   %td.supplier-table__complaints
     %span.cads-table__content
       = render ScoreComponent.new(score: supplier.complaints_rating)
@@ -14,6 +17,3 @@
   %td.supplier-table__guarantee
     %span.cads-table__content
       = render ScoreComponent.new(score: supplier.guarantee_rating)
-  %td
-    %span.cads-table__content
-      = render_overall_score


### PR DESCRIPTION
The [AbilityNet accessibility review](https://drive.google.com/file/d/1V6ZGHdse7TLIKKf9CinA38oXAJCQd-kr/view) identified a disparity of information available to those using 400% zoom (or a mobile device), as the supplier comparison table that they were served only gave the overall ranking score for each supplier, rather than also including the three sub-categories that comprise that score. This is ADR-10 in the AbilityNet review.

This PR introduces a horizontally scrolling table, to ensure that all users have access to the same information. `cads-table-container` already has `overflow: auto`.

This is shown as v3 on the [Figma designs](https://www.figma.com/file/6L8z0dFIXxZ1PICcHKd7G4/Energy-2023-WIP---Catherine-T?type=design&node-id=593-23316&mode=design&t=EVadWKB6erwK0jVu-0)