### PR TITLE
feat: update quarter dates March 2024

### DIFF
--- a/app/components/score_summary_component.html.haml
+++ b/app/components/score_summary_component.html.haml
@@ -1,7 +1,7 @@
 .score-summary
   .cads-prose
     %h2.score-summary__heading
-      #{supplier.name} scores for July to September 2023
+      #{supplier.name} scores for October to December 2023
 
   %ul.score-summary__list
     %li.score-summary__item

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -5,7 +5,7 @@ module ContentHelper
     [
       {
         id: scores_fragment,
-        label: "#{supplier_name} score for July to September 2023"
+        label: "#{supplier_name} score for October to December 2023"
       },
       {
         id: contact_details_fragment,

--- a/app/views/suppliers/index.html.haml
+++ b/app/views/suppliers/index.html.haml
@@ -10,9 +10,9 @@
     We’ve compared the largest suppliers across 3 different categories and ranked their customer services. We’ve scored each supplier out of 5.
     = link_to("Find out how the scores are worked out.", country_url("/consumer/energy/energy-supply/get-a-better-energy-deal/compare-domestic-energy-suppliers-customer-service1/how-the-scores-are-worked-out/"))
   %h2
-    Scores for July to September 2023
+    Scores for October to December 2023
   %p
-    We will publish updated scores for the following 3 months in March 2024.
+    We will publish updated scores for the following 3 months in June 2024.
 
 = render SupplierTableComponent.new(ranked_suppliers)
 

--- a/spec/components/score_summary_component_spec.rb
+++ b/spec/components/score_summary_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ScoreSummaryComponent, type: :component do
     render_inline described_class.new(supplier)
   end
 
-  it { is_expected.to have_text "An Energy Supplier Inc scores for July to September 2023" }
+  it { is_expected.to have_text "An Energy Supplier Inc scores for October to December 2023" }
   it { is_expected.to have_selector ".stars", count: 4 }
 
   context "when there is no supplier" do


### PR DESCRIPTION
Updates dates on the app to reflect new quarter data for October to December 2023, and next publishing date of June 2024.

Note: do not merge in until the date that the next quarter's data is published. This is anticipated to be 26th March, but not yet confirmed.