### PR TITLE
Use test data in qa environment

### DIFF
--- a/infrastructure/app/stages/dev.yaml
+++ b/infrastructure/app/stages/dev.yaml
@@ -19,6 +19,7 @@ annotations:
 
 envVars:
   RAILS_ENV: production
+  USE_TEST_SUPPLIERS: ${{ vars.USE_TEST_SUPPLIERS }}
 
 autoscaling:
   enabled: true


### PR DESCRIPTION
Currently both the prod and qa environments use production data.

This PR adds the `USE_TEST_SUPPLIERS` environment variable to the deployment pipeline, so that qa can use test data instead.