### PR TITLE
Feat/add other contact info for small suppliers

### DIFF
--- a/app/components/unranked_suppliers/details_component.rb
+++ b/app/components/unranked_suppliers/details_component.rb
@@ -34,6 +34,10 @@ module UnrankedSuppliers
           description: opening_hours
         },
         {
+          term: content_tag(:h4, "Ways to contact"),
+          description: other_contact_info
+        },
+        {
           term: content_tag(:h4, "Billing information"),
           description: billing_info
         },
@@ -46,6 +50,10 @@ module UnrankedSuppliers
 
     def contact_info
       renderer.render_with_breaks(supplier.contact_info)
+    end
+
+    def other_contact_info
+      renderer.render_with_breaks(supplier.other_contact_info)
     end
 
     def billing_info

--- a/spec/components/unranked_suppliers/details_component_spec.rb
+++ b/spec/components/unranked_suppliers/details_component_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe UnrankedSuppliers::DetailsComponent, type: :component do
   it { is_expected.to have_text "some contact details" }
   it { is_expected.to have_text "some more" }
   it { is_expected.to have_selector "br" }
+  it { is_expected.to have_text "other ways to contact" }
   it { is_expected.to have_text "opening hours content" }
   it { is_expected.to have_text "fuel mix content" }
   it { is_expected.to have_text "billing info content" }

--- a/spec/factories/supplier.rb
+++ b/spec/factories/supplier.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     opening_hours { { json: JSON.parse(File.read("spec/fixtures/opening_hours.json")) } }
     fuel_mix { { json: JSON.parse(File.read("spec/fixtures/fuel_mix.json")) } }
     guarantee_list { { json: JSON.parse(File.read("spec/fixtures/guarantee_list.json")) } }
+    other_contact_info { { json: JSON.parse(File.read("spec/fixtures/other_contact_info.json")) } }
 
     trait :ranked do
       data_available { true }

--- a/spec/fixtures/other_contact_info.json
+++ b/spec/fixtures/other_contact_info.json
@@ -1,0 +1,18 @@
+{
+  "data": {},
+  "content": [
+    {
+      "data": {},
+      "content": [
+        {
+          "data": {},
+          "marks": [],
+          "value": "other ways to contact",
+          "nodeType": "text"
+        }
+      ],
+      "nodeType": "paragraph"
+    }
+  ],
+  "nodeType": "document"
+}


### PR DESCRIPTION
Other ways to contact small suppliers weren't being displayed, as the unranked suppliers details component hadn't been updated when the contact information was split across two places for ranked suppliers. 

This PR fixes this, so that all ways to contact small suppliers are now displayed.