### PR TITLE
Upgrade node-based GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,7 +43,7 @@ jobs:
       name: ${{ matrix.stage }}
     steps:
       - name: Git Checkout energy comparison table
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: energy-comparison-table
       - name: Set environment variables from cdk context

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Setup ruby"
         uses: ruby/setup-ruby@v1
@@ -16,7 +16,7 @@ jobs:
           bundler-cache: true
 
       - name: "Setup node"
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
@@ -37,7 +37,7 @@ jobs:
     needs: lint
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Setup ruby"
         uses: ruby/setup-ruby@v1
@@ -45,7 +45,7 @@ jobs:
           bundler-cache: true
 
       - name: "Setup node"
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
@@ -63,7 +63,7 @@ jobs:
     needs: lint
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Setup ruby"
         uses: ruby/setup-ruby@v1
@@ -90,7 +90,7 @@ jobs:
     needs: lint
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Setup ruby"
         uses: ruby/setup-ruby@v1
@@ -98,7 +98,7 @@ jobs:
           bundler-cache: true
 
       - name: "Setup node"
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/review-app-create.yml
+++ b/.github/workflows/review-app-create.yml
@@ -49,7 +49,7 @@ jobs:
     needs: build
     steps:
       - name: Git Checkout energy comparison table
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: energy-comparison-table
 
@@ -102,7 +102,7 @@ jobs:
           energy-comparison-table/infrastructure/app/chart/energy-comparison-table
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3
         id: find-comment
         if: contains(github.event.pull_request.labels.*.name, 'Review app')
         with:
@@ -112,7 +112,7 @@ jobs:
           direction: last
 
       - name: Add New Comment
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v4
         if: steps.find-comment.outputs.comment-id == 0 && contains(github.event.pull_request.labels.*.name, 'Review app')
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -128,7 +128,7 @@ jobs:
             To destroy the review app remove the label `Review app`, close this PR or convert it to draft.
 
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v4
         if: steps.find-comment.outputs.comment-id && contains(github.event.pull_request.labels.*.name, 'Review app')
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/review-app-destroy.yml
+++ b/.github/workflows/review-app-destroy.yml
@@ -53,7 +53,7 @@ jobs:
           number: ${{ github.event.issue.number || github.event.pull_request.number || inputs.pr_number }}
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3
         id: find-comment
         with:
           issue-number: ${{ env.PR_NUMBER }}
@@ -62,7 +62,7 @@ jobs:
           direction: last
 
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v4
         if: steps.find-comment.outputs.comment-id
         with:
           issue-number: ${{ env.PR_NUMBER }}


### PR DESCRIPTION
These actions were using Node.js 16, which is deprecated. The latest versions use Node.js 20.