### PR TITLE
Use patched review app scan script to prevent errors when array is empty

### DIFF
--- a/.github/workflows/review-app-scan.yml
+++ b/.github/workflows/review-app-scan.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check Review Environments
         id: scan
         run: |
-          pip3 install git+https://github.com/citizensadvice/review-app-scan@v1.2.1
+          pip3 install git+https://github.com/citizensadvice/review-app-scan@v1.2.2
           python3 -m review_app_scan energy-comparison-table dev-energy-comparison-table
 
   trigger_destroy:


### PR DESCRIPTION
This uses a patched version of the review app scan script that will prevent workflow errors when the list of namespaces is empty.