### PR TITLE
Add quarter dates feature flag as environment variable for production

### DIFF
--- a/infrastructure/app/stages/prod.yaml
+++ b/infrastructure/app/stages/prod.yaml
@@ -12,6 +12,7 @@ ingress:
 
 envVars:
   RAILS_ENV: production
+  FF_CONTENTFUL_QTR_DATES: ${{ vars.FF_CONTENTFUL_QTR_DATES }}
 
 autoscaling:
   enabled: true


### PR DESCRIPTION
Adds feature flag to env vars list for GH actions. Have also added an env var to the prod environment of the repo within GH settings.