### PR TITLE
Upgrade rack to address security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,7 +315,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.0)
-    rack (3.1.4)
+    rack (3.1.6)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)


### PR DESCRIPTION
Manually upgraded `rack` to 3.1.6, as dependabot couldn't create a PR to address the security vulnerability.