### PR TITLE
chore: remove feature flag FF_CONTENTFUL_QTR_DATES

### DIFF
--- a/app/views/suppliers/index.html.haml
+++ b/app/views/suppliers/index.html.haml
@@ -9,18 +9,11 @@
   %p
     We’ve compared the largest suppliers across 3 different categories and ranked their customer services. We’ve scored each supplier out of 5.
     = link_to("Find out how the scores are worked out.", country_url("/consumer/energy/energy-supply/get-a-better-energy-deal/compare-domestic-energy-suppliers-customer-service1/how-the-scores-are-worked-out/"))
-  - if Feature.enabled? "FF_CONTENTFUL_QTR_DATES"
-    %h2
-      Scores for #{quarter_date.body}
+  %h2
+    Scores for #{quarter_date.body}
 
-    %p
+  %p
     We will publish updated scores for the following 3 months in #{next_quarter_release.body}.
-  - else
-    %h2
-      Scores for October to December 2023
-
-    %p
-      We will publish updated scores for the following 3 months in June 2024.
 
 = render SupplierTableComponent.new(ranked_suppliers)
 

--- a/app/views/suppliers/show.html.haml
+++ b/app/views/suppliers/show.html.haml
@@ -3,12 +3,8 @@
     #{supplier.name} customer service
 
   = render LocationSwitcherComponent.new(current_country:)
-  - if Feature.enabled? "FF_CONTENTFUL_QTR_DATES"
-    = render CitizensAdviceComponents::OnThisPage.new do |c|
-      - c.with_links(on_this_page_links(supplier.name, quarter_date.body))
-  - else
-    = render CitizensAdviceComponents::OnThisPage.new do |c|
-      - c.with_links(on_this_page_links(supplier.name, "October to December 2023"))
+  = render CitizensAdviceComponents::OnThisPage.new do |c|
+    - c.with_links(on_this_page_links(supplier.name, quarter_date.body))
 
   .cads-prose
     %p
@@ -16,10 +12,7 @@
     %p
       The ratings are calculated using information from different sources, including Citizens Advice, Energy Ombudsman and the suppliers.
 
-  - if Feature.enabled? "FF_CONTENTFUL_QTR_DATES"
-    = render ScoreSummaryComponent.new(supplier, quarter_date.body)
-  - else
-    = render ScoreSummaryComponent.new(supplier, "October to December 2023")
+  = render ScoreSummaryComponent.new(supplier, quarter_date.body)
 
   .cads-prose
     %p

--- a/infrastructure/app/stages/dev.yaml
+++ b/infrastructure/app/stages/dev.yaml
@@ -20,7 +20,6 @@ annotations:
 envVars:
   RAILS_ENV: production
   USE_TEST_SUPPLIERS: ${{ vars.USE_TEST_SUPPLIERS }}
-  FF_CONTENTFUL_QTR_DATES: ${{ vars.FF_CONTENTFUL_QTR_DATES }}
 
 autoscaling:
   enabled: true

--- a/infrastructure/app/stages/prod.yaml
+++ b/infrastructure/app/stages/prod.yaml
@@ -12,7 +12,6 @@ ingress:
 
 envVars:
   RAILS_ENV: production
-  FF_CONTENTFUL_QTR_DATES: ${{ vars.FF_CONTENTFUL_QTR_DATES }}
 
 autoscaling:
   enabled: true


### PR DESCRIPTION
Always serve quarter dates from Contentful.