### PR TITLE
feat: set review apps to use dev env vars

### DIFF
--- a/.github/resources/preview-overrides.yaml
+++ b/.github/resources/preview-overrides.yaml
@@ -12,3 +12,8 @@ ingress:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/healthcheck-path: /status
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+
+envVars:
+  RAILS_ENV: production
+  USE_TEST_SUPPLIERS: ${{ vars.USE_TEST_SUPPLIERS }}
+  FF_SMALL_SUPPLIER_STARS: ${{ vars.FF_SMALL_SUPPLIER_STARS }}


### PR DESCRIPTION
Review apps currently use secrets defined in github dev environment, but not the environment variables defined there. This PR brings parity of approach.

See the [review app created by #348](https://review-348-energy-comparison-table.qa.citizensadvice.org.uk/) for comparison. That review app uses the live supplier data, whereas this one uses test supplier data.