### PR TITLE
chore: bump rexml version to fix Dependabot alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,7 +369,7 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
-    rexml (3.3.1)
+    rexml (3.3.2)
       strscan
     rich_text_renderer (0.3.2)
     rspec-core (3.13.0)


### PR DESCRIPTION
Bumps rexml to 3.3.2 to address moderate security vulnerability CVE-2024-39908. Dependabot was unable to raise the PR for this.