### PR TITLE
feat: turn on small supplier stars feature in production

### DIFF
--- a/infrastructure/app/stages/prod.yaml
+++ b/infrastructure/app/stages/prod.yaml
@@ -12,6 +12,7 @@ ingress:
 
 envVars:
   RAILS_ENV: production
+  FF_SMALL_SUPPLIER_STARS: ${{ vars.FF_SMALL_SUPPLIER_STARS }}
 
 autoscaling:
   enabled: true


### PR DESCRIPTION
Have also set the env var of FF_SMALL_SUPPLIER_STARS in the production github environment.