### PR TITLE
Feat/1482 empty headings

### DIFF
--- a/app/assets/stylesheets/components/_fuel-mix.scss
+++ b/app/assets/stylesheets/components/_fuel-mix.scss
@@ -1,11 +1,15 @@
 .fuel-mix {
   .descriptions__list {
     margin: 0;
+  }
+
+  .descriptions__description {
+    margin: 0;
 
     @extend %cads-list-unordered;
   }
 
-  .descriptions__description {
+  .descriptions__intro {
     margin: 0;
   }
 }

--- a/app/assets/stylesheets/components/_other-info.scss
+++ b/app/assets/stylesheets/components/_other-info.scss
@@ -6,4 +6,8 @@
   .descriptions__description {
     margin: 0;
   }
+
+  .descriptions__intro {
+    display: none;
+  }
 }

--- a/app/assets/stylesheets/components/_other-scores.scss
+++ b/app/assets/stylesheets/components/_other-scores.scss
@@ -46,4 +46,8 @@
       margin-bottom: 0;
     }
   }
+
+  .descriptions__intro {
+    display: none;
+  }
 }

--- a/app/assets/stylesheets/components/_unranked-supplier.scss
+++ b/app/assets/stylesheets/components/_unranked-supplier.scss
@@ -48,6 +48,10 @@
     }
   }
 
+  .descriptions__intro {
+    display: none;
+  }
+
   .descriptions__term {
     padding: $cads-spacing-2 $cads-spacing-2 0 $cads-spacing-2;
 

--- a/app/components/description_list_component.html.haml
+++ b/app/components/description_list_component.html.haml
@@ -6,5 +6,7 @@
     - descriptions.each do |description|
       %dt.descriptions__term
         = description.term
+      %dd.descriptions__intro
+        = description.intro
       %dd.descriptions__description
         = description.description

--- a/app/components/description_list_component.rb
+++ b/app/components/description_list_component.rb
@@ -9,11 +9,12 @@ class DescriptionListComponent < ViewComponent::Base
   end
 
   class DescriptionComponent < ViewComponent::Base
-    attr_reader :term, :description
+    attr_reader :term, :description, :intro
 
-    def initialize(term:, description:)
+    def initialize(term:, description:, intro: nil)
       @term = term
       @description = description
+      @intro = intro
     end
   end
 end

--- a/app/components/fuel_mix_component.html.haml
+++ b/app/components/fuel_mix_component.html.haml
@@ -1,9 +1,5 @@
 .fuel-mix
   .cads-prose
-    %h3
-      Fuel Mix
-    %p
-      The fuel mix is the percentage of energy sources used by this supplier. #{supplier.name} uses:
 
     = render DescriptionListComponent.new do |c|
       - c.with_descriptions(descriptions)

--- a/app/components/fuel_mix_component.rb
+++ b/app/components/fuel_mix_component.rb
@@ -17,7 +17,8 @@ class FuelMixComponent < ViewComponent::Base
   def descriptions
     [
       {
-        term: content_tag(:h3, ""),
+        term: content_tag(:h3, "Fuel Mix"),
+        intro: fuel_mix_intro,
         description: fuel_mix
       }
     ].reject { |desc| desc[:description].blank? }
@@ -25,5 +26,9 @@ class FuelMixComponent < ViewComponent::Base
 
   def fuel_mix
     renderer.render_without_breaks(supplier.fuel_mix)
+  end
+
+  def fuel_mix_intro
+    content_tag(:p, "The fuel mix is the percentage of energy sources used by this supplier. #{supplier.name} uses:")
   end
 end

--- a/spec/components/description_list_component_spec.rb
+++ b/spec/components/description_list_component_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe DescriptionListComponent, type: :component do
     [
       {
         term: "First term",
+        intro: "First term introduction",
         description: "First term description"
       },
       {
@@ -32,7 +33,9 @@ RSpec.describe DescriptionListComponent, type: :component do
   it { is_expected.to have_css "dt", count: 2 }
   it { is_expected.to have_css "dt", text: "First term" }
   it { is_expected.to have_css "dt", text: "Second term" }
-  it { is_expected.to have_css "dd", count: 2 }
+  it { is_expected.to have_css "dd", count: 4 }
+  it { is_expected.to have_css "dd", text: "First term introduction" }
+  it { is_expected.to have_css "dd", text: "" }
   it { is_expected.to have_css "dd", text: "First term description" }
   it { is_expected.to have_css "dd", text: "Second term description" }
 


### PR DESCRIPTION
Removes empty heading from fuel mix component, to address ADR6 from [AbilityNet accessibility review](https://drive.google.com/file/d/1V6ZGHdse7TLIKKf9CinA38oXAJCQd-kr/view).