### PR TITLE
Make environment variables info easier to find

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This repo contains example data for automated testing. For the latest energy sup
 
 See [getting-started.md](./docs/getting-started.md)
 
+## Environment variables & secrets
+
+Environment variables and secrets are stored within the relevant environment(s) in the GitHub repo, not in Vault. See [configuration section in Infrastructure docs.](./infrastructure/README.md#configuration)
+
 ## View components
 
 This project uses view components for front end logic and rendering - see [view-components.md](./docs/view-components.md)


### PR DESCRIPTION
The main repo documentation didn't previously refer to environment variables or secrets, but they were mentioned within the infrastructure README. This PR adds a link to Configuration section of the infrastructure README to the main repo README, so that environment variable information can be found easily.