### PR TITLE
fix: move straight to small supplier details when one has been selected

### DIFF
--- a/app/views/suppliers/index.html.haml
+++ b/app/views/suppliers/index.html.haml
@@ -36,7 +36,7 @@
     %p
       Select the supplier you want to check using the dropdown to see any customer service information we have.
 
-%form.unranked-suppliers__form
+%form.unranked-suppliers__form{ method: "GET", action: "#h-unranked-supplier", id: "h-unranked-supplier" }
   = render UnrankedSuppliers::DropdownComponent.new(unranked_suppliers, chosen_supplier_slug: unranked_supplier&.slug)
   = render CitizensAdviceComponents::Button.new(variant: :primary, attributes: { class: unranked_supplier_button_classes }, type: :submit) do
     Search


### PR DESCRIPTION
Adds a fragment id to both the small suppliers form and to the action of the form, so that when the user chooses a small supplier they are taken to the small supplier details and not sent back to the top of the page.