### PR TITLE
feat: add prod back into matrix

### DIFF
--- a/.github/workflows/deploy-energy-apps.yaml
+++ b/.github/workflows/deploy-energy-apps.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        stage: ["dev"]
+        stage: ["dev", "prod"]
     environment:
       name: ${{ matrix.stage }}
     steps:


### PR DESCRIPTION
Adds `prod` back into the deployment GHA workflow, so the app is also deployed to the new prod environment.

Protection rules prevent this workflow deploying into prod from a branch (https://github.com/citizensadvice/energy-comparison-table/actions/runs/11495591764/job/31995501661)