### PR TITLE
chore: add docker image scan workflow to repo

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -1,0 +1,69 @@
+name: Docker Image Security Scan
+
+on:
+  schedule:
+    # Runs at 10:00 AM UTC every Monday
+    - cron: '0 10 * * 1'
+  # Optional: Allow manual triggering
+  workflow_dispatch:
+
+jobs:
+  scan:
+    name: Scan Latest Image
+    runs-on: runs-on
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::979633842206:role/EnergyAppsDeployment
+          role-session-name: energy-apps-trivy-scan
+          aws-region: eu-west-1
+
+      - name: ECR login
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: private
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        id: trivy-scan
+        env:
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_DISABLE_VEX_NOTICE: true
+        with:
+          image-ref: ${{ steps.ecr-login.outputs.registry }}/energy-apps:latest
+          format: 'json'
+          output: 'trivy-results.json'
+          ignore-unfixed: true
+
+      - name: Upload scan results
+        id: upload-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-scan-results
+          path: trivy-results.json
+          retention-days: 7
+
+      - name: Install Dependency
+        run: pip install git+https://github.com/citizensadvice/trivy-image-slack-reporter.git@2.0.0
+
+      - name: Send Slack notification
+        env:
+          RESULTS_FILE: trivy-results.json
+          ARTIFACT_URL: ${{ steps.upload-artifact.outputs.artifact-url }}
+          IMAGE_TITLE: Energy Apps
+          SEVERITY: HIGH,CRITICAL
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: "C08LQKF02TA" #content-platform_security
+        run: python3 -m trivy_image_slack_reporter


### PR DESCRIPTION
Adds docker image scan to repo. Haven't added the `.trivyignore` file yet with the exclusion for the CVE on net-imap as I want to run the workflow first to see if that comes up as a vulnerability.