### PR TITLE
fix: supply probe target from values.yaml

### DIFF
--- a/infrastructure/app/chart/energy-apps/templates/probe.yaml
+++ b/infrastructure/app/chart/energy-apps/templates/probe.yaml
@@ -14,7 +14,5 @@ spec:
   prober:
     path: /probe
     url: prometheus-blackbox-exporter.kube-monitoring.svc.cluster.local:9115
-  targets:
-    staticConfig:
-      static: []
+  targets: {{ .Values.ingress.probe.targets | toYaml | nindent 4 }}
 {{- end }}

--- a/infrastructure/app/chart/energy-apps/values.yaml
+++ b/infrastructure/app/chart/energy-apps/values.yaml
@@ -56,10 +56,8 @@ service:
 
 ingress:
   probe:
-    enabled: false
-    targets:
-      staticConfig:
-        static: []
+    enabled: true
+    targets: {}
   enabled: false
   hostname: energy-apps.minikube
   annotations:


### PR DESCRIPTION
Hopefully will allow the helm chart to build the uptime monitoring probe correctly. 