### PR TITLE
chore/Stop automatically rebasing Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    target-branch: 'main'
+    rebase-strategy: "disabled"
 
   - package-ecosystem: npm
     directory: '/'
@@ -35,6 +37,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    target-branch: 'main'
+    rebase-strategy: "disabled"
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -49,6 +53,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    target-branch: 'main'
+    rebase-strategy: "disabled"
 
   - package-ecosystem: 'pip'
     directory: '/infrastructure/cdk'
@@ -67,6 +73,8 @@ updates:
           # Pre-release libraries should be handled individually
           # to keep PRs easier to understand
           - "ruff"
+    target-branch: 'main'
+    rebase-strategy: "disabled"
 
   - package-ecosystem: 'docker'
     directory: '/'


### PR DESCRIPTION
Whenever a PR is merged then any open Dependabot PRs get rebased.  This can mean multiple PRs getting rebased multiple times, which is resource heavy and time consuming.  We've turned off this feature in public-website and want to extend it to a few other core repos