### PR TITLE
ci(review-app): Update to use new configmap subns anchors

### DIFF
--- a/.github/workflows/review-app-create.yml
+++ b/.github/workflows/review-app-create.yml
@@ -67,12 +67,15 @@ jobs:
       - name: Create Sub-namespace
         run: |
           kubectl apply -f - << EOF
-          apiVersion: hnc.x-k8s.io/v1alpha2
-          kind: SubnamespaceAnchor
+          apiVersion: v1
+          kind: ConfigMap
           metadata:
-            name: ${{ env.NAMESPACE }}
+            name: '${{ env.NAMESPACE }}-namespace-anchor'
             namespace: "dev-energy-apps"
-          EOF
+            annotations:
+              citizensadvice.org.uk/subnamespace-anchor: "true"
+              citizensadvice.org.uk/subnamespace-name: ${{ env.NAMESPACE }}
+          data: {}
 
       - name: Escape Characters
         id: escape_chars

--- a/.github/workflows/review-app-destroy.yml
+++ b/.github/workflows/review-app-destroy.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Destroy Review App
         run: |
           if [[ $(helm status -n ${{ env.NAMESPACE }} ${{ env.NAMESPACE }}) ]] ; then
-            kubectl delete subnamespaceanchor ${{ env.NAMESPACE }} -n dev-energy-apps
+            kubectl delete configmap ${{ env.NAMESPACE }}-namespace-anchor -n dev-energy-apps
           fi
 
       - name: Remove Review app label

--- a/.github/workflows/review-app-scan.yml
+++ b/.github/workflows/review-app-scan.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check Review Environments
         id: scan
         run: |
-          pip3 install git+https://github.com/citizensadvice/review-app-scan@v1.2.2
+          pip3 install git+https://github.com/citizensadvice/review-app-scan@v2.0.0
           python3 -m review_app_scan energy-apps dev-energy-apps
 
   trigger_destroy:


### PR DESCRIPTION
Replace custom resource namespace anchors with equivalent configmaps so that Kyverno can create the subnamespaces instead of the deprecated Hierarchical Namespace controller.

- https://citizensadvice.atlassian.net/wiki/spaces/OPS/pages/5263327257/Kubernetes+How+To+Self-Service+Subnamespaces+Review+Apps
- https://acab.slack.com/archives/GD5E1DS7R/p1777463904904739
- https://github.com/citizensadvice/eks-platform-cdk/pull/817
