### PR TITLE
[CP-1380] Update the default unit rate for July 2026

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -77,6 +77,6 @@ module EnergyComparisonTable
 
     config.session_store :disabled
 
-    config.x.default_unit_rate = 24.67
+    config.x.default_unit_rate = 26.11
   end
 end


### PR DESCRIPTION
Default unit rate for the energy appliance calculator will change to 26.11 pence per kWh from the 1st July.