### PR TITLE
chore: update cookie preferences gem to v0.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "citizens_advice_components",
 
 gem "citizens_advice_cookie_preferences",
     github: "citizensadvice/cookie-preferences",
-    tag: "v0.4.2"
+    tag: "v0.5.0"
 
 # The citizens_advice_components gem uses view component but we also use this to write
 # our app components so explicitly name it as an application dependency.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,10 +21,10 @@ GIT
 
 GIT
   remote: https://github.com/citizensadvice/cookie-preferences.git
-  revision: b213b668adbab61f8c5321ff447c25e3b6f7d3ea
-  tag: v0.4.2
+  revision: a98fb04be831fcb9e7692010a64100c976ebd5c6
+  tag: v0.5.0
   specs:
-    citizens_advice_cookie_preferences (0.4.2)
+    citizens_advice_cookie_preferences (0.5.0)
       addressable (~> 2.7)
       citizens_advice_components (> 8.0.0)
       meta-tags


### PR DESCRIPTION
Only resetting the cookies if the cookie_preference_set version is older than the current