### PR TITLE
feat: major upgrade to v1.1.0 of cookie preferences gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "citizens_advice_components",
 
 gem "citizens_advice_cookie_preferences",
     github: "citizensadvice/cookie-preferences",
-    tag: "v0.5.0"
+    tag: "v1.1.0"
 
 # The citizens_advice_components gem uses view component but we also use this to write
 # our app components so explicitly name it as an application dependency.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,10 +21,10 @@ GIT
 
 GIT
   remote: https://github.com/citizensadvice/cookie-preferences.git
-  revision: a98fb04be831fcb9e7692010a64100c976ebd5c6
-  tag: v0.5.0
+  revision: 34f3cde1b47b7c87d4cbd894d48e5d7137105902
+  tag: v1.1.0
   specs:
-    citizens_advice_cookie_preferences (0.5.0)
+    citizens_advice_cookie_preferences (1.1.0)
       addressable (~> 2.7)
       citizens_advice_components (> 8.0.0)
       meta-tags

--- a/app/controllers/concerns/data_layer.rb
+++ b/app/controllers/concerns/data_layer.rb
@@ -27,10 +27,13 @@ module DataLayer
       language: (helpers.current_country || "england").to_s.capitalize
     }
 
+    properties[:surveyCookiesAccepted] = "true" if allow_survey_cookies?
+
+    # If the user has accepted cookies the dlv is set to explicit
     if allow_analytics_cookies?
-      properties.merge({ analyticsCookiesAccepted: "True" })
-    else
-      properties
+      properties[:analyticsCookiesAccepted] = cookies[:cookie_preference_set].present? ? "explicit" : "default"
     end
+
+    properties
   end
 end


### PR DESCRIPTION
This sets the analytics tracking by default until a user rejects the cookies. It also introduces a new 'survey' cookies category which is currently used for Ethnio.